### PR TITLE
Fixing problem with ridley gem

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name		 "xhprof"
 maintainer       "Mark Sonnabaum"
 maintainer_email "mark.sonnabaum@acquia.com"
 license           "Apache 2.0"


### PR DESCRIPTION
```
~/.vagrant.d/gems/gems/ridley-3.0.0/lib/ridley/chef/cookbook.rb:44:in `from_path': The metadata at '/tmp/d20140417-1167-1bym92e' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry. (Ridley::Errors::MissingNameAttribute)
```

more info here: https://github.com/msonnabaum/chef-xhprof/issues/7
